### PR TITLE
Fix a warning when rightclick-opening a tray popup menu

### DIFF
--- a/dbus/dbus_status.py
+++ b/dbus/dbus_status.py
@@ -238,10 +238,7 @@ class StatusIcon:
         self.run_yumex.set_sensitive(sensitive)
 
     def on_popup(self, icon, button, time):
-        def pos(menu, icon):
-            return (Gtk.StatusIcon.position_menu(menu, icon))
-
-        self.popup_menu.popup(None, None, pos, self.statusicon, button, time)
+        self.popup_menu.popup(None, None, self.statusicon.position_menu, self.statusicon, button, time)
 
     def get_status_icon(self):
         return self.statusicon


### PR DESCRIPTION
Currently on F22 when opening a popup menu on yumex's status icon I get this message on stderr:
`TypeError: pos() takes 2 positional arguments but 4 were given`
This is caused by an API break in Gtk3's GObject/Python bindings, see https://github.com/lazka/pgi-docgen/issues/92 for details.

This change fixes the issue for me on F22/Gtk+ 3.16. Needs testing on 3.18 and 3.14, I can't do that right now.

If this change doesn't work on all supported Gtk versions, another idea can be found in https://github.com/exaile/exaile/pull/112