### PR TITLE
Remove deprecated python option `-tt`

### DIFF
--- a/dbus/dbus_status.py
+++ b/dbus/dbus_status.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -tt
+#!/usr/bin/python3
 # -*- coding: iso-8859-1 -*-
 #    Yum Exteder (yumex) - A GUI for yum
 #    Copyright (C) 2013 Tim Lauridsen < timlau<AT>fedoraproject<DOT>org >


### PR DESCRIPTION
The `-t` option was removed in python3. It has no effect any more and is ignored. It can be safely removed. See https://bugzilla.redhat.com/show_bug.cgi?id=1268262