### PR TITLE
Require Gtk version 3.10

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -22,6 +22,7 @@ import sys
 import traceback
 import subprocess
 import signal
+import gi
 
 here = sys.path[0]
 if here != '/usr/bin':
@@ -33,6 +34,7 @@ if here != '/usr/bin':
 from yumex import YumexApplication
 try:
     signal.signal(signal.SIGINT, signal.SIG_DFL)
+    gi.require_version('Gtk', '3.10')
     app = YumexApplication()
     exit_status = app.run(sys.argv)
     sys.exit(exit_status)


### PR DESCRIPTION
This fixes some warnings from gi. I chose Gtk 3.10 since yumex-dnf uses `GtkHeaderBar`s which require 3.10.