### PR TITLE
Font sizes

### DIFF
--- a/src/yumex.ui
+++ b/src/yumex.ui
@@ -1176,7 +1176,7 @@ start Yum Extender</property>
                 </child>
                 <child>
                   <object class="GtkLabel" id="infobar_sublabel">
-                    <property name="visible">True</property>
+                    <property name="visible">False</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="margin_left">20</property>
@@ -1186,7 +1186,7 @@ start Yum Extender</property>
                     <property name="hexpand">True</property>
                     <property name="label" translatable="yes">label</property>
                     <attributes>
-                      <attribute name="font-desc" value="&lt;Enter Value&gt; 8"/>
+                      <attribute name="scale" value="0.85"/>
                       <attribute name="stretch" value="condensed"/>
                     </attributes>
                   </object>

--- a/src/yumex/const.py
+++ b/src/yumex/const.py
@@ -68,11 +68,6 @@ ICON_TRAY_UPDATES = PIX_DIR + '/tray-updates.png'
 ICON_TRAY_WORKING = PIX_DIR + '/tray-working.png'
 ICON_TRAY_INFO = PIX_DIR + '/tray-info.png'
 
-# Fonts
-XSMALL_FONT = Pango.FontDescription("sans 6")
-SMALL_FONT = Pango.FontDescription("sans 8")
-BIG_FONT = Pango.FontDescription("sans 12")
-
 # Constants
 
 # Main UI stack names

--- a/src/yumex/gui/views.py
+++ b/src/yumex/gui/views.py
@@ -898,7 +898,6 @@ class HistoryView(Gtk.TreeView):
         @param widget:
         '''
         Gtk.TreeView.__init__(self)
-        self.modify_font(const.SMALL_FONT)
         self.model = self.setup_view()
         self.base = base
         self.pkg_view = HistoryPackageView(self.base)
@@ -979,7 +978,6 @@ class HistoryPackageView(Gtk.TreeView):
         @param widget:
         '''
         Gtk.TreeView.__init__(self)
-        self.modify_font(const.SMALL_FONT)
         self.model = self.setup_view()
         self.base = base
 
@@ -1143,12 +1141,10 @@ class TextViewBase(Gtk.TextView):
         if not tag:
             if check_dark_theme():
                 tag = self.buffer.create_tag(text,
-                                             foreground="#4C4CFF",
-                                             font_desc=const.SMALL_FONT)
+                                             foreground="#4C4CFF")
             else:
                 tag = self.buffer.create_tag(text,
-                                             foreground="blue",
-                                             font_desc=const.SMALL_FONT)
+                                             foreground="blue")
             tag.connect("event", self.on_url_event)
             self.url_tags.append(tag)
             self.url_list[text] = url
@@ -1234,12 +1230,11 @@ class PackageInfoView(TextViewBase):
     TextView handler for showing package information
     '''
 
-    def __init__(self, window=None, url_handler=None, font_size=9):
+    def __init__(self, window=None, url_handler=None):
         '''
         Setup the textview
 
         :param textview: the Gtk.TextView widget to use
-        :param font_size: default text size
         '''
         TextViewBase.__init__(self, window, url_handler)
 
@@ -1251,7 +1246,6 @@ class PackageInfoView(TextViewBase):
         else:
             style.set_property("foreground", "midnight blue")
         style.set_property("family", "Monospace")
-        style.set_property("size_points", font_size)
         self.add_style(tag, style)
         self.default_style = tag
 
@@ -1260,7 +1254,6 @@ class PackageInfoView(TextViewBase):
         style = Gtk.TextTag()
         style.set_property("foreground", "DarkOrchid4")
         style.set_property("family", "Monospace")
-        style.set_property("size_points", font_size)
         self.add_style(tag, style)
 
         # changelog style
@@ -1271,7 +1264,6 @@ class PackageInfoView(TextViewBase):
         else:
             style.set_property("foreground", "midnight blue")
         style.set_property("family", "Monospace")
-        style.set_property("size_points", font_size)
         self.add_style(tag, style)
 
         # changelog style
@@ -1282,7 +1274,6 @@ class PackageInfoView(TextViewBase):
         else:
             style.set_property("foreground", "dark red")
         style.set_property("family", "Monospace")
-        style.set_property("size_points", font_size)
         self.add_style(tag, style)
 
 


### PR DESCRIPTION
infobar_sublabel: Fix visibility, use relative font. 
Without this change infobar_sublabel is visible by default.
It uses an absolute font which is not required but might interfere with users choosing their own custom font size.

Improve readability, remove hard-coded font sizes
GtkTextView is using small font sizes anyway (10 instead of default 11) so there is no need to make it even smaller.