### PR TITLE
Fix main GtkPaned being to small

### DIFF
--- a/src/yumex.ui
+++ b/src/yumex.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.19.0 -->
+<!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.16"/>
   <object class="GtkAdjustment" id="ad_update_startup_delay">
@@ -1351,7 +1351,7 @@ start Yum Extender</property>
               </object>
               <packing>
                 <property name="resize">False</property>
-                <property name="shrink">True</property>
+                <property name="shrink">False</property>
               </packing>
             </child>
             <child>
@@ -1496,7 +1496,7 @@ start Yum Extender</property>
               </object>
               <packing>
                 <property name="resize">False</property>
-                <property name="shrink">True</property>
+                <property name="shrink">False</property>
               </packing>
             </child>
           </object>


### PR DESCRIPTION
Without this fix, the GtkPaned could be resized in a way that one of its child widgets partially or completely got hidden.
