### PR TITLE
InfoBar: remove custom colors and code

### DIFF
--- a/src/yumex.ui
+++ b/src/yumex.ui
@@ -871,8 +871,8 @@ start Yum Extender</property>
               <object class="GtkButton" id="sch_options_button">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
                 <property name="focus_on_click">False</property>
+                <property name="receives_default">True</property>
                 <child>
                   <object class="GtkImage" id="image4">
                     <property name="visible">True</property>
@@ -905,43 +905,53 @@ start Yum Extender</property>
       <packing>
         <property name="expand">False</property>
         <property name="fill">True</property>
-        <property name="position">1</property>
+        <property name="position">2</property>
       </packing>
     </child>
     <child>
-      <object class="GtkRevealer" id="infobar">
+      <object class="GtkInfoBar" id="infobar">
         <property name="visible">True</property>
+        <property name="app_paintable">True</property>
         <property name="can_focus">False</property>
-        <child>
-          <object class="GtkFrame" id="info_frame">
-            <property name="visible">True</property>
+        <property name="border_width">5</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
             <property name="can_focus">False</property>
-            <property name="margin_left">6</property>
-            <property name="margin_right">6</property>
-            <property name="margin_start">5</property>
-            <property name="margin_end">5</property>
-            <property name="margin_top">6</property>
-            <property name="margin_bottom">6</property>
-            <property name="label_xalign">0</property>
-            <property name="shadow_type">in</property>
+            <property name="spacing">6</property>
+            <property name="layout_style">end</property>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child internal-child="content_area">
+          <object class="GtkBox">
+            <property name="can_focus">False</property>
             <child>
               <object class="GtkGrid" id="info_grid">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="margin_top">6</property>
-                <property name="margin_bottom">6</property>
                 <property name="hexpand">True</property>
                 <property name="row_spacing">6</property>
+                <property name="column_spacing">5</property>
                 <child>
                   <object class="GtkLabel" id="infobar_label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="margin_left">6</property>
-                    <property name="margin_right">6</property>
                     <property name="margin_start">6</property>
                     <property name="margin_end">10</property>
-                    <property name="hexpand">True</property>
                     <property name="label" translatable="yes">label</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
@@ -956,27 +966,22 @@ start Yum Extender</property>
                   <object class="GtkProgressBar" id="infobar_progress">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_left">12</property>
-                    <property name="margin_right">12</property>
                     <property name="margin_start">10</property>
                     <property name="margin_end">10</property>
                     <property name="hexpand">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
+                    <property name="left_attach">1</property>
                     <property name="top_attach">1</property>
-                    <property name="width">2</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="infobar_sublabel">
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="margin_left">20</property>
-                    <property name="margin_right">10</property>
+                    <property name="margin_left">16</property>
                     <property name="margin_start">20</property>
                     <property name="margin_end">10</property>
-                    <property name="hexpand">True</property>
                     <property name="label" translatable="yes">label</property>
                     <attributes>
                       <attribute name="scale" value="0.84999999999999998"/>
@@ -984,36 +989,44 @@ start Yum Extender</property>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
+                    <property name="left_attach">1</property>
                     <property name="top_attach">2</property>
-                    <property name="width">2</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkSpinner" id="info_spinner">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_left">12</property>
-                    <property name="margin_right">6</property>
                     <property name="active">True</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
                     <property name="top_attach">0</property>
+                    <property name="height">3</property>
                   </packing>
                 </child>
               </object>
-            </child>
-            <child type="label_item">
-              <placeholder/>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
             </child>
           </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
         </child>
       </object>
       <packing>
         <property name="expand">False</property>
         <property name="fill">True</property>
-        <property name="position">2</property>
+        <property name="position">0</property>
       </packing>
     </child>
     <child>

--- a/src/yumex/gui/widgets.py
+++ b/src/yumex/gui/widgets.py
@@ -47,44 +47,42 @@ class InfoProgressBar:
     def __init__(self, ui):
         self.ui = ui
         self.infobar = ui.get_object("infobar")  # infobar revealer
-        frame = ui.get_object("info_frame")
-        new_bg = Gdk.RGBA()
-        if yumex.misc.check_dark_theme():
-            new_bg.parse("rgb(0,0,0)")
-        else:
-            new_bg.parse("rgb(255,255,255)")
-        frame.override_background_color(Gtk.StateFlags.NORMAL, new_bg)
         self.label = ui.get_object("infobar_label")
         self.sublabel = ui.get_object("infobar_sublabel")
         self.progress = ui.get_object("infobar_progress")
+        self.spinner = ui.get_object("info_spinner")
 
     def _show_infobar(self, show=True):
-        self.infobar.set_reveal_child(show)
+        if show:
+            self.infobar.show()
+            self.spinner.start()
+        else:
+            self.spinner.stop()
+            self.infobar.hide()
+            self.label.hide()
+            self.sublabel.hide()
+            self.progress.hide()
+            self.progress.set_show_text(False)
 
     def show_progress(self, state):
         if state:
             self.show_label()
         else:
-            self.hide()
+            self._show_infobar(False)
 
     def hide(self):
-        self.label.hide()
-        self.sublabel.hide()
-        self.progress.hide()
         self._show_infobar(False)
-        self.progress.set_text("")
-        #self.progress.set_show_text (False)
 
     def hide_sublabel(self):
         self.sublabel.hide()
 
-    def show_label(self):
+    def show_label(self, msg=""):
+        self.label.set_text(msg)
         self.label.show()
-        self.label.set_text("")
 
-    def show_sublabel(self):
+    def show_sublabel(self, msg=""):
+        self.sublabel.set_text(msg)
         self.sublabel.show()
-        self.sublabel.set_text("")
 
     def show_all(self):
         self.show_label()
@@ -93,25 +91,27 @@ class InfoProgressBar:
 
     def info(self, msg):
         self._show_infobar(True)
-        self.show_label()
-        self.label.set_text(msg)
+        self.show_label(msg)
 
     def info_sub(self, msg):
         self._show_infobar(True)
-        self.show_sublabel()
-        self.sublabel.set_text(msg)
+        self.show_sublabel(msg)
 
     def set_progress(self, frac, label=None):
         if label:
             self.progress.set_text(label)
+            self.progress.set_show_text(True)
+        else:
+            self.progress.set_show_text(False)
+
         if frac >= 0.0 and frac <= 1.0:
-            self.infobar.show()
+            self._show_infobar()
             self.progress.show()
             self.progress.set_fraction(frac)
-            # make sure that the main label is shown, else the progres
-            # looks bad. this is normally happen when changlog
-            # or filelist info is needed for at package
-            # and it will trigger the yum daemon to download the need metadata.
+            # make sure that the main label is shown, else the progress
+            # looks bad. this normally happens when changlog or filelist info
+            # is needed for a package and it will trigger the yum daemon to
+            # download the need metadata.
             if not self.label.get_property('visible'):
                 self.info(_("Getting Package Metadata"))
 


### PR DESCRIPTION
Rely on Gtk theme for coloring the info bar.
Use a GtkInfoBar.

This will fix #87.
