### PR TITLE
Reorder extra search filter popover elements

### DIFF
--- a/src/yumex.ui
+++ b/src/yumex.ui
@@ -763,93 +763,6 @@ start Yum Extender</property>
       <action-widget response="1">error_ok</action-widget>
     </action-widgets>
   </object>
-  <object class="GtkGrid" id="grid_more_filters">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="row_spacing">6</property>
-    <property name="column_spacing">12</property>
-    <child>
-      <object class="GtkLabel" id="label_pkg_version">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="halign">start</property>
-        <property name="margin_left">6</property>
-        <property name="label" translatable="yes">&lt;b&gt;Package Versions&lt;/b&gt;</property>
-        <property name="use_markup">True</property>
-      </object>
-      <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">0</property>
-        <property name="width">3</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkLabel" id="label_archs">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="halign">start</property>
-        <property name="margin_left">6</property>
-        <property name="label" translatable="yes">&lt;b&gt;Archs&lt;/b&gt;</property>
-        <property name="use_markup">True</property>
-      </object>
-      <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">3</property>
-        <property name="width">3</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkBox" id="box_archs">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="margin_left">12</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-      </object>
-      <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">4</property>
-        <property name="width">3</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkSeparator" id="separator2">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
-      </object>
-      <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">1</property>
-        <property name="width">3</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkCheckButton" id="cb_newest_only">
-        <property name="label" translatable="yes">Newest Only</property>
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
-        <property name="tooltip_text" translatable="yes">Show only the latest package versions</property>
-        <property name="halign">start</property>
-        <property name="margin_left">12</property>
-        <property name="draw_indicator">True</property>
-      </object>
-      <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">2</property>
-        <property name="width">3</property>
-      </packing>
-    </child>
-  </object>
   <object class="GtkHeaderBar" id="headerbar">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -1682,6 +1595,196 @@ start Yum Extender</property>
       </packing>
     </child>
   </object>
+  <object class="GtkPopover" id="more_filters_popover">
+    <property name="can_focus">False</property>
+    <property name="relative_to">button_more_filters</property>
+    <child>
+      <object class="GtkGrid" id="more_filters_grid">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="row_spacing">6</property>
+        <property name="column_spacing">12</property>
+        <child>
+          <object class="GtkLabel" id="label_pkg_version">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="label" translatable="yes">&lt;b&gt;Package Versions&lt;/b&gt;</property>
+            <property name="use_markup">True</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+            <property name="width">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="label_archs">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="label" translatable="yes">&lt;b&gt;Archs&lt;/b&gt;</property>
+            <property name="use_markup">True</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">3</property>
+            <property name="width">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="box_archs">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">4</property>
+            <property name="width">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSeparator" id="separator2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">2</property>
+            <property name="width">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="cb_newest_only">
+            <property name="label" translatable="yes">Newest Only</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes">Show only the latest package versions</property>
+            <property name="halign">start</property>
+            <property name="draw_indicator">True</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">1</property>
+            <property name="width">3</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkPopover" id="sch_opt_popover">
+    <property name="can_focus">False</property>
+    <property name="relative_to">sch_options_button</property>
+    <property name="position">bottom</property>
+    <child>
+      <object class="GtkGrid" id="sch_opt_grid">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkRadioButton" id="sch_opt_prefix">
+            <property name="label" translatable="yes">Prefix</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes">Package names starting with search key</property>
+            <property name="active">True</property>
+            <property name="draw_indicator">True</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkRadioButton" id="sch_opt_keyword">
+            <property name="label" translatable="yes">Keyword</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes">Package names containing search key</property>
+            <property name="draw_indicator">True</property>
+            <property name="group">sch_opt_prefix</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkRadioButton" id="sch_opt_fields">
+            <property name="label" translatable="yes">Fields</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes">Specified package fields containing search keys.</property>
+            <property name="draw_indicator">True</property>
+            <property name="group">sch_opt_prefix</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="sch_fld_name">
+            <property name="label" translatable="yes">Name</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes">Package name</property>
+            <property name="margin_left">24</property>
+            <property name="draw_indicator">True</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="sch_fld_summary">
+            <property name="label" translatable="yes">Summary</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes">Package summary</property>
+            <property name="margin_left">24</property>
+            <property name="draw_indicator">True</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="sch_fld_description">
+            <property name="label" translatable="yes">Description</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes">Package description</property>
+            <property name="margin_left">24</property>
+            <property name="draw_indicator">True</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">5</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
   <object class="GtkMenu" id="queue_menu">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -1760,101 +1863,6 @@ start Yum Extender</property>
         <property name="expand">False</property>
         <property name="fill">True</property>
         <property name="position">2</property>
-      </packing>
-    </child>
-  </object>
-  <object class="GtkGrid" id="sch_opt_grid">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="column_spacing">6</property>
-    <child>
-      <object class="GtkRadioButton" id="sch_opt_prefix">
-        <property name="label" translatable="yes">Prefix</property>
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
-        <property name="tooltip_text" translatable="yes">Package names starting with search key</property>
-        <property name="active">True</property>
-        <property name="draw_indicator">True</property>
-      </object>
-      <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">0</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkRadioButton" id="sch_opt_keyword">
-        <property name="label" translatable="yes">Keyword</property>
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
-        <property name="tooltip_text" translatable="yes">Package names containing search key</property>
-        <property name="draw_indicator">True</property>
-        <property name="group">sch_opt_prefix</property>
-      </object>
-      <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">1</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkRadioButton" id="sch_opt_fields">
-        <property name="label" translatable="yes">Fields</property>
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
-        <property name="tooltip_text" translatable="yes">Specified package fields containing search keys.</property>
-        <property name="draw_indicator">True</property>
-        <property name="group">sch_opt_prefix</property>
-      </object>
-      <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">2</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkCheckButton" id="sch_fld_name">
-        <property name="label" translatable="yes">Name</property>
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
-        <property name="tooltip_text" translatable="yes">Package name</property>
-        <property name="margin_left">24</property>
-        <property name="draw_indicator">True</property>
-      </object>
-      <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">3</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkCheckButton" id="sch_fld_summary">
-        <property name="label" translatable="yes">Summary</property>
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
-        <property name="tooltip_text" translatable="yes">Package summary</property>
-        <property name="margin_left">24</property>
-        <property name="draw_indicator">True</property>
-      </object>
-      <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">4</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkCheckButton" id="sch_fld_description">
-        <property name="label" translatable="yes">Description</property>
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
-        <property name="tooltip_text" translatable="yes">Package description</property>
-        <property name="margin_left">24</property>
-        <property name="draw_indicator">True</property>
-      </object>
-      <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">5</property>
       </packing>
     </child>
   </object>

--- a/src/yumex.ui
+++ b/src/yumex.ui
@@ -1813,29 +1813,18 @@ start Yum Extender</property>
       </packing>
     </child>
     <child>
-      <object class="GtkSeparator" id="separator1">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
-      </object>
-      <packing>
-        <property name="left_attach">1</property>
-        <property name="top_attach">0</property>
-        <property name="height">3</property>
-      </packing>
-    </child>
-    <child>
       <object class="GtkCheckButton" id="sch_fld_name">
         <property name="label" translatable="yes">Name</property>
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="tooltip_text" translatable="yes">Package name</property>
+        <property name="margin_left">24</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
-        <property name="left_attach">2</property>
-        <property name="top_attach">0</property>
+        <property name="left_attach">0</property>
+        <property name="top_attach">3</property>
       </packing>
     </child>
     <child>
@@ -1845,11 +1834,12 @@ start Yum Extender</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="tooltip_text" translatable="yes">Package summary</property>
+        <property name="margin_left">24</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
-        <property name="left_attach">2</property>
-        <property name="top_attach">1</property>
+        <property name="left_attach">0</property>
+        <property name="top_attach">4</property>
       </packing>
     </child>
     <child>
@@ -1859,11 +1849,12 @@ start Yum Extender</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="tooltip_text" translatable="yes">Package description</property>
+        <property name="margin_left">24</property>
         <property name="draw_indicator">True</property>
       </object>
       <packing>
-        <property name="left_attach">2</property>
-        <property name="top_attach">2</property>
+        <property name="left_attach">0</property>
+        <property name="top_attach">5</property>
       </packing>
     </child>
   </object>

--- a/src/yumex/gui/widgets.py
+++ b/src/yumex/gui/widgets.py
@@ -161,11 +161,7 @@ class SearchBar(GObject.GObject):
                 wid.set_active(True)
             wid.connect('toggled', self.on_type_changed, key)
         # setup search option popover
-        self.opt_popover = Gtk.Popover.new(self._options_button)
-        self.opt_popover.set_size_request(50, 100)
-        self.opt_popover.set_position(Gtk.PositionType.BOTTOM)
-        opt_grid = self.win.get_ui('sch_opt_grid')
-        self.opt_popover.add(opt_grid)
+        self.opt_popover = self.win.get_ui('sch_opt_popover')
 
     def show_spinner(self, state=True):
         """Set is spinner in searchbar is running."""
@@ -763,10 +759,7 @@ class ExtraFilters(GObject.GObject):
         self.current_archs = None
         self._button = self.win.get_ui('button_more_filters')
         self._button.connect('clicked', self._on_button)
-        self._popover = Gtk.Popover.new(self._button)
-        self._popover.set_position(Gtk.PositionType.BOTTOM)
-        grid = self.win.get_ui('grid_more_filters')
-        self._popover.add(grid)
+        self._popover = self.win.get_ui('more_filters_popover')
         self._arch_box = self.win.get_ui('box_archs')
         self._setup_archs()
         self.newest_only = self.win.get_ui('cb_newest_only')


### PR DESCRIPTION
Change arrangement of checkboxes to follow functionality.
Move creation of Popovers into yumex.ui file.

Any objections?
