### PR TITLE
About Dialog: make window transient

### DIFF
--- a/src/yumex/__init__.py
+++ b/src/yumex/__init__.py
@@ -1003,7 +1003,7 @@ class Window(BaseWindow):
             if self.can_close():
                 self.app.quit()
         elif action == 'about':
-            dialog = dialogs.AboutDialog()
+            dialog = dialogs.AboutDialog(self)
             dialog.run()
             dialog.destroy()
         elif action == 'docs':

--- a/src/yumex/gui/dialogs.py
+++ b/src/yumex/gui/dialogs.py
@@ -37,7 +37,7 @@ logger = logging.getLogger('yumex.gui.dialogs')
 
 class AboutDialog(Gtk.AboutDialog):
 
-    def __init__(self):
+    def __init__(self, parent):
         Gtk.AboutDialog.__init__(self)
         self.props.program_name = 'Yum Extender (dnf)'
         self.props.version = const.VERSION
@@ -46,6 +46,7 @@ class AboutDialog(Gtk.AboutDialog):
         self.props.copyright = '(C) 2015 Tim Lauridsen'
         self.props.website = 'https://github.com/timlau/yumex-dnf'
         self.props.logo_icon_name = 'yumex-dnf'
+        self.set_transient_for(parent)
 
 
 class Preferences:


### PR DESCRIPTION
Windows without parents are discouraged. Before this change and with `G_ENABLE_DIAGNOSTIC=1` you'll see the warning `Gtk-Message: GtkDialog mapped without a transient parent. This is discouraged.` when opening the AboutDialog.
