### PR TITLE
Internationalization: Plurals fixed

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -6,7 +6,6 @@ src/yumex/backend.py
 src/yumex/dnf_backend.py
 src/yumex/misc.py
 src/yumex/const.py
-src/yumex/old_init.py
 src/yumex/updater.py
 src/yumex/gui/views.py
 src/yumex/gui/__init__.py

--- a/src/yumex/__init__.py
+++ b/src/yumex/__init__.py
@@ -28,7 +28,7 @@ import sys
 
 from gi.repository import Gio, Gtk, Gdk
 
-from yumex.misc import _, CONFIG
+from yumex.misc import _, ngettext, CONFIG
 import yumex.const as const
 import yumex.misc as misc
 import yumex.dnf_backend
@@ -817,13 +817,17 @@ class Window(BaseWindow):
 
         if rc == 4:  # Download errors
             dialogs.show_information(
-                self, _('Downloading error(s)\n'),
+                self,
+                ngettext('Downloading error\n',
+                         'Downloading errors\n', len(result)),
                 '\n'.join(result))
             self._reset_on_cancel()
             return
         elif rc != 0:  # other transaction errors
             dialogs.show_information(
-                self, _('Error in transaction\n'),
+                self,
+                ngettext('Error in transaction\n',
+                         'Errors in transaction\n', len(result)),
                 '\n'.join(result))
         self._reset()
         return
@@ -870,7 +874,9 @@ class Window(BaseWindow):
                 misc.notify('Yum Extender', exit_msg)
         else:
             dialogs.show_information(
-                self, _('Error(s) in search for dependencies'),
+                self,
+                ngettext('Error in search for dependencies',
+                         'Errors in search for dependencies', len(result)),
                 '\n'.join(result))
         if app_quit:
             self.release_root_backend(quit_dnfdaemon=True)
@@ -897,7 +903,8 @@ class Window(BaseWindow):
             check = self._check_protected(result)
             if check:
                 self.error_dialog.show(
-                    _("Can't remove protected package(s):") +
+                    ngettext("Can't remove protected package:",
+                             "Can't remove protected packages:", len(check)) +
                     misc.list_to_string(check, "\n ", ",\n "))
                 self._reset_on_cancel()
                 return
@@ -916,11 +923,14 @@ class Window(BaseWindow):
         except misc.TransactionBuildError as e:
             # Error in building transaction
             self.error_dialog.show(
-                _('Error(s) in building transaction') + '\n'.join(e.msgs))
+                ngettext('Error in building transaction',
+                         'Errors in building transaction', len(e.msgs)) +
+                    '\n'.join(e.msgs))
             self._reset_on_cancel()
         except misc.TransactionSolveError as e:
             self.error_dialog.show(
-                    _('Error(s) in search for dependencies') +
+                    ngettext('Error in search for dependencies',
+                             'Errors in search for dependencies', len(e.msgs)) +
                     '\n'.join(e.msgs))
             self._reset_on_error()
 

--- a/src/yumex/dnf_backend.py
+++ b/src/yumex/dnf_backend.py
@@ -27,7 +27,7 @@ import dnfdaemon.client
 import yumex.backend
 import yumex.misc
 import yumex.const as const
-from yumex.misc import ExceptionHandler, TimeFunction, _, CONFIG
+from yumex.misc import ExceptionHandler, TimeFunction, _, ngettext, CONFIG
 
 logger = logging.getLogger('yumex.yum_backend')
 
@@ -241,7 +241,12 @@ class DnfRootBackend(yumex.backend.Backend, dnfdaemon.client.Client):
         self._files_downloaded = 0
         self.frontend.infobar.set_progress(0.0)
         self.frontend.infobar.info_sub(
-            _('Downloading %d files (%sB)...') %
+            # Translators: %d will be replaced with the number of files
+            # to download; %s will be replaced with the preformatted
+            # number of bytes to download + the prefix (k, M, etc.)
+            # Note that 'B' for 'bytes' is already here, it must be preserved.
+            ngettext('Downloading %d file (%sB)...',
+                     'Downloading %d files (%sB)...', num_files) %
             (num_files, yumex.misc.format_number(num_bytes)))
 
     def on_DownloadProgress(self, name, frac, total_frac, total_files):

--- a/src/yumex/gui/views.py
+++ b/src/yumex/gui/views.py
@@ -27,7 +27,7 @@ from gi.repository import GdkPixbuf
 from gi.repository import GObject
 
 from yumex import const
-from yumex.misc import _, P_, CONFIG, doGtkEvents, TimeFunction
+from yumex.misc import _, ngettext, CONFIG, doGtkEvents, TimeFunction
 import yumex.misc as misc
 
 logger = logging.getLogger('yumex.gui.views')
@@ -800,38 +800,38 @@ class QueueView(Gtk.TreeView):
         """ Populate view with data from queue """
         self.store.clear()
         pkg_list = self.queue.packages['u'] + self.queue.packages['o']
-        label = "<b>%s</b>" % P_(
+        label = "<b>%s</b>" % ngettext(
             "Package to update", "Packages to update", len(pkg_list))
         if len(pkg_list) > 0:
             self.populate_list(label, pkg_list)
         pkg_list = self.queue.packages['i']
-        label = "<b>%s</b>" % P_(
+        label = "<b>%s</b>" % ngettext(
             "Package to install", "Packages to install", len(pkg_list))
         if len(pkg_list) > 0:
             self.populate_list(label, pkg_list)
         pkg_list = self.queue.packages['r']
-        label = "<b>%s</b>" % P_(
+        label = "<b>%s</b>" % ngettext(
             "Package to remove", "Packages to remove", len(pkg_list))
         if len(pkg_list) > 0:
             self.populate_list(label, pkg_list)
         pkg_list = self.queue.packages['ri']
-        label = "<b>%s</b>" % P_(
+        label = "<b>%s</b>" % ngettext(
             "Package to reinstall", "Packages to reinstall", len(pkg_list))
         if len(pkg_list) > 0:
             self.populate_list(label, pkg_list)
         pkg_list = self.queue.packages['li']
-        label = "<b>%s</b>" % P_(
+        label = "<b>%s</b>" % ngettext(
             "RPM file to install", "RPM files to install", len(pkg_list))
         if len(pkg_list) > 0:
             self.populate_list(label, pkg_list)
         grps = self.queue.groups['i']
-        label = "<b>%s</b>" % P_(
+        label = "<b>%s</b>" % ngettext(
             "Group to install", "Groups to install", len(pkg_list))
         if len(grps) > 0:
             self.populate_group_list(label, grps)
         grps = self.queue.groups['r']
-        label = "<b>%s</b>" % P_(
-            "Group to remove", "Groups files to remove", len(pkg_list))
+        label = "<b>%s</b>" % ngettext(
+            "Group to remove", "Groups to remove", len(pkg_list))
         if len(grps) > 0:
             self.populate_group_list(label, grps)
         self.populate_list_downgrade()
@@ -850,7 +850,7 @@ class QueueView(Gtk.TreeView):
 
     def populate_list_downgrade(self):
         pkg_list = self.queue.packages['do']
-        label = "<b>%s</b>" % P_(
+        label = "<b>%s</b>" % ngettext(
             "Package to downgrade", "Packages to downgrade", len(pkg_list))
         if len(pkg_list) > 0:
             parent = self.store.append(None, [label, ""])

--- a/src/yumex/misc.py
+++ b/src/yumex/misc.py
@@ -40,7 +40,7 @@ locale.bindtextdomain('yumex-dnf', LOCALE_DIR)
 gettext.bindtextdomain('yumex-dnf', LOCALE_DIR)
 gettext.textdomain('yumex-dnf')
 _ = gettext.gettext
-P_ = gettext.ngettext
+ngettext = gettext.ngettext
 
 logger = logging.getLogger('yumex.misc')
 

--- a/src/yumex/updater.py
+++ b/src/yumex/updater.py
@@ -35,7 +35,7 @@ from xdg import BaseDirectory
 
 import dnfdaemon.client
 
-from yumex.misc import _, CONFIG
+from yumex.misc import _, ngettext, CONFIG
 import yumex.misc as misc
 
 LOG_ROOT = 'yumex.updater'
@@ -158,7 +158,10 @@ class _Updater:
                     logger.debug('notification opened : # updates = %d',
                                  update_count)
                     notify = _Notification(_('New Updates'),
-                                           _('%s available updates')
+                    # Translators: %d is a number of available updates
+                                           ngettext('%d available update',
+                                                    '%d available updates',
+                                                    update_count)
                                            % update_count)
                     notify.connect('notify-action', self.__on_notify_action)
                     notify.show()


### PR DESCRIPTION
All occurrences of ```P_``` replaced with ```ngettext``` which is correctly
understood by gettext tools.  Also ```ngettext()``` applied to few more
messages where it seemed to be necessary to distinguish between
plural and singular.

At the same time, a reference to no longer existing ```old_init.py```
removed from ```POTFILES.in```.

I've also decided to reword ```"Groups files to remove"``` to
```"Groups to remove"``` because I guess this is what you actually meant.

Closes #139