### PR TITLE
Fix invisible text (regression b92762d5114b808917eef69fc57872ccdb0497d5)

### DIFF
--- a/data/ui/yumex.ui
+++ b/data/ui/yumex.ui
@@ -100,7 +100,6 @@
         <property name="font">Normal</property>
         <property name="family">Monospace</property>
         <property name="size-points">12</property>
-        <property name="scale">0</property>
       </object>
     </child>
     <child type="tag">


### PR DESCRIPTION
Hello! I've noticed that the content of the Package Filelist section was empty, but when looking into the code it seems that the scale of the text was 0, so it was invisible. It seems that scale 0 was a bug from b92762d5114b808917eef69fc57872ccdb0497d5

Let me know if I need to do something else, it's my first contribution in this repository.