### PR TITLE
make sure autostart user folder exists before attempting to copy file…

### DIFF
--- a/src/yumex/gui/window/__init__.py
+++ b/src/yumex/gui/window/__init__.py
@@ -106,6 +106,8 @@ class Window(BaseWindow):
             os.unlink(const.LEGACY_DESKTOP_FILE)
         if CONFIG.conf.autostart:
             if not os.path.exists(const.USER_DESKTOP_FILE):
+                if not os.path.exists(const.AUTOSTART_DIR):
+                    os.mkdir(const.AUTOSTART_DIR)
                 logger.debug(f"create autostart: {const.USER_DESKTOP_FILE}")
                 shutil.copy(const.SYS_DESKTOP_FILE, const.USER_DESKTOP_FILE)
         # key is renamed to keyword


### PR DESCRIPTION
…s to it

On my KDE installation the ~/.config/autostart/ folder did not exist, which led to myself (and other KDE users on my distro) hitting this bug:

$ yumex-dnf
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/yumex/__init__.py", line 55, in on_activate
    self.window = Window(
  File "/usr/lib/python3.10/site-packages/yumex/gui/window/__init__.py", line 64, in __init__
    self.legacy_cleanup()
  File "/usr/lib/python3.10/site-packages/yumex/gui/window/__init__.py", line 110, in legacy_cleanup
    shutil.copy(const.SYS_DESKTOP_FILE, const.USER_DESKTOP_FILE)
  File "/usr/lib64/python3.10/shutil.py", line 417, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib64/python3.10/shutil.py", line 256, in copyfile
    with open(dst, 'wb') as fdst:
FileNotFoundError: [Errno 2] No such file or directory: '/home/tcrider/.config/autostart/yumex-dnf-updater.desktop'

This patch makes sure ~/.config/autostart folder exists before attempting to copy the yumex-dnf-updater.desktop file to it, and if not creates it.